### PR TITLE
spanner: 2.1

### DIFF
--- a/Spanner.md
+++ b/Spanner.md
@@ -37,9 +37,9 @@ Spanner universe是由多个zones组成的。每个zone都类似于一个Bigtabl
 
 ### 2.1 Spanserver软件栈
 
-这一章节主要通过介绍spanserver的实现来解释如何在基于类似Bigtable的实现上完成复制和分布式事务。图2显示了spanserver的软件栈。在最底部，每个spanserver负责管理成百上千个被成为tablet的数据结构实体。每一个tablet类似于Bigtable的tablet，因为它也实现了如下的映射关系：
+这一章节主要通过介绍spanserver的实现来解释如何在基于类似Bigtable的实现上完成复制和分布式事务功能。图2显示了spanserver的软件栈。在最底部，每个spanserver负责管理成百上千个被成为tablet的数据结构实体。Tablet类似于Bigtable的tablet，因为它也实现了如下的映射关系：
 ```
 (key:string, timestamp:int64) -> string
 ```
-不同于Bigtable, Spanner会分配给data对应的时间戳。 这也是Spanner相比于键值存更像多版本数据库的重要原因。每一个tablet的状态被存在一个类似B-tree的文件集合和一个write-ahead日志中。文件和日志都被存储在Colossus(即Google File System [15]的继承系统)分布式文件系统中。
+不同于Bigtable, Spanner会分配给tablet数据时间戳。 这也是Spanner相比于键值存更像多版本数据库的重要原因。每一个tablet的状态被存在一个类似B-tree的文件集合和一个write-ahead日志中。文件和日志都被存储在Colossus(即Google File System [15]的继承系统)分布式文件系统中。
 

--- a/Spanner.md
+++ b/Spanner.md
@@ -37,7 +37,7 @@ Spanner universe是由多个zones组成的。每个zone都类似于一个Bigtabl
 
 ### 2.1 Spanserver软件栈
 
-这一章节主要通过介绍spanserver的实现来解释如何在基于类似Bigtable的实现上完成复制和分布式事务功能。图2显示了spanserver的软件栈。在最底部，每个spanserver负责管理成百上千个被成为tablet的数据结构实体。Tablet类似于Bigtable的tablet，因为它也实现了如下的映射关系：
+这一章节主要关注spanserver的实现,并介绍如何在基于类似Bigtable的tablet上实现复制和分布式事能。图2显示了spanserver的软件栈。在最底部，每个spanserver负责管理成百上千个被成为tablet的数据结构实体。Tablet类似于Bigtable的tablet，因为它也实现了如下的映射关系：
 ```
 (key:string, timestamp:int64) -> string
 ```


### PR DESCRIPTION
This section focuses on the spanserver implementation to illustrate how replication and distributed transactions have been layered onto our Bigtable-based implementa- tion. The software stack is shown in Figure 2. At the bottom, each spanserver is responsible for between 100 and 1000 instances of a data structure called a tablet. A tablet is similar to Bigtable’s tablet abstraction, in that it implements a bag of the following mappings:
(key:string, timestamp:int64) → string
Unlike Bigtable, Spanner assigns timestamps to data, which is an important way in which Spanner is more like a multi-version database than a key-value store. A tablet’s state is stored in set of B-tree-like files and a write-ahead log, all on a distributed file system called Colossus (the successor to the Google File System [15]).